### PR TITLE
Call GatherWriterStatus instead of GatherWriterMetadata after BackupComplete

### DIFF
--- a/IVssBackupComponents.go
+++ b/IVssBackupComponents.go
@@ -159,6 +159,22 @@ func (vss *IVssBackupComponents) GatherWriterMetadata() (*IVssAsync, error) {
 	}
 }
 
+// The GatherWriterStatus method prompts each writer to send a status message.
+func (vss *IVssBackupComponents) GatherWriterStatus() (*IVssAsync, error) {
+	var unknown *ole.IUnknown
+	code, _, _ := syscall.Syscall(vss.getVTable().gatherWriterStatus, 2, uintptr(unsafe.Pointer(vss)), uintptr(unsafe.Pointer(&unknown)), 0)
+	if code != 0 {
+		return nil, CreateVSSError("IVssBackupComponents.GatherWriterStatus", code)
+	}
+
+	if comInterface, err := queryInterface(unknown, UIID_IVSS_ASYNC); err != nil {
+		return nil, CreateVSSError("IVssBackupComponents.GatherWriterStatus", code)
+	} else {
+		iVssAsync := (*IVssAsync)(unsafe.Pointer(comInterface))
+		return iVssAsync, CreateVSSError("IVssBackupComponents.GatherWriterStatus", code)
+	}
+}
+
 // The BackupComplete method causes VSS to generate a BackupComplete event, which signals writers that the backup process has completed.
 func (vss *IVssBackupComponents) BackupComplete() (*IVssAsync, error) {
 	var unknown *ole.IUnknown

--- a/IVssBackupComponents.go
+++ b/IVssBackupComponents.go
@@ -175,6 +175,22 @@ func (vss *IVssBackupComponents) GatherWriterStatus() (*IVssAsync, error) {
 	}
 }
 
+// The GatherWriterStatus method prompts each writer to send a status message.
+func (vss *IVssBackupComponents) FreeWriterStatus() (*IVssAsync, error) {
+	var unknown *ole.IUnknown
+	code, _, _ := syscall.Syscall(vss.getVTable().freeWriterStatus, 2, uintptr(unsafe.Pointer(vss)), uintptr(unsafe.Pointer(&unknown)), 0)
+	if code != 0 {
+		return nil, CreateVSSError("IVssBackupComponents.FreeWriterStatus", code)
+	}
+
+	if comInterface, err := queryInterface(unknown, UIID_IVSS_ASYNC); err != nil {
+		return nil, CreateVSSError("IVssBackupComponents.FreeWriterStatus", code)
+	} else {
+		iVssAsync := (*IVssAsync)(unsafe.Pointer(comInterface))
+		return iVssAsync, CreateVSSError("IVssBackupComponents.FreeWriterStatus", code)
+	}
+}
+
 // The BackupComplete method causes VSS to generate a BackupComplete event, which signals writers that the backup process has completed.
 func (vss *IVssBackupComponents) BackupComplete() (*IVssAsync, error) {
 	var unknown *ole.IUnknown

--- a/vss_windows.go
+++ b/vss_windows.go
@@ -15,6 +15,10 @@ type Snapshotter struct {
 }
 
 func (v *Snapshotter) CreateSnapshot(drive string, bootable bool, timeout int) (s *Snapshot, rerr error) {
+	if v.components != nil {
+		return nil, fmt.Errorf("snapshotter is already in use")
+	}
+
 	if timeout < 180 {
 		timeout = 180
 	}
@@ -132,6 +136,10 @@ func (v *Snapshotter) CreateSnapshot(drive string, bootable bool, timeout int) (
 }
 
 func (v *Snapshotter) Release() error {
+	if v.components == nil {
+		return nil
+	}
+
 	var async *IVssAsync
 	var err error
 
@@ -175,6 +183,7 @@ func (v *Snapshotter) Release() error {
 
 	async.Release()
 	v.components.Release()
+	v.components = nil
 
 	return nil
 }

--- a/vss_windows.go
+++ b/vss_windows.go
@@ -147,15 +147,15 @@ func (v *Snapshotter) Release() error {
 
 	async.Release()
 
-	// TODO: GatherWriterMetadata should request check writers status and fail execution if any writer is in a failed state
-	if async, err = v.components.GatherWriterMetadata(); err != nil {
-		return fmt.Errorf("VSS_GATHER - Shadow copy creation failed: GatherWriterMetadata, err: %s", err)
+	// TODO: GatherWriterStatus should request check writers status and fail execution if any writer is in a failed state
+	if async, err = v.components.GatherWriterStatus(); err != nil {
+		return fmt.Errorf("VSS_GATHER - Shadow copy creation failed: GatherWriterStatus, err: %s", err)
 	} else if async == nil {
-		return fmt.Errorf("VSS_GATHER - Shadow copy creation failed: GatherWriterMetadata failed to return a valid IVssAsync object")
+		return fmt.Errorf("VSS_GATHER - Shadow copy creation failed: GatherWriterStatus failed to return a valid IVssAsync object")
 	}
 
 	if err = async.Wait(v.timeout); err != nil {
-		return fmt.Errorf("VSS_GATHER - Shadow copy creation failed: GatherWriterMetadata didn't finish properly, err: %s", err)
+		return fmt.Errorf("VSS_GATHER - Shadow copy creation failed: GatherWriterStatus didn't finish properly, err: %s", err)
 	}
 
 	async.Release()


### PR DESCRIPTION
GatherWriterMetadata should be called only once during the lifetime of a given [IVssBackupComponents](https://learn.microsoft.com/en-us/windows/desktop/api/vsbackup/nl-vsbackup-ivssbackupcomponents) object.
After calling BackupComplete, requesters must call [GatherWriterStatus](https://learn.microsoft.com/en-us/windows/desktop/api/vsbackup/nf-vsbackup-ivssbackupcomponents-gatherwriterstatus) to cause the writer session to be set to a completed state.

And also the caller of GatherWriterStatus should also call [FreeWriterStatus](https://learn.microsoft.com/en-us/windows/desktop/api/vsbackup/nf-vsbackup-ivssbackupcomponents-freewriterstatus) after receiving the status of each writer.