### PR TITLE
Fix snapshotter timeout handling

### DIFF
--- a/IVssAsync.go
+++ b/IVssAsync.go
@@ -40,14 +40,14 @@ func (async *IVssAsync) Wait(miliseconds int) error {
 	return nil
 }
 
-func (async *IVssAsync) QueryStatus() (int32, error) {
+func (async *IVssAsync) QueryStatus() (HRESULT, error) {
 	var status int32
 	code, _, _ := syscall.Syscall(async.getVTable().queryStatus, 3, uintptr(unsafe.Pointer(async)), uintptr(unsafe.Pointer(&status)), 0)
 	if err := CreateVSSError("IVssAsync.QueryStatus", code); err != nil {
 		return 0, err
 	}
 
-	return status, nil
+	return HRESULT(status), nil
 }
 
 func (async *IVssAsync) Cancel() error {

--- a/IVssAsync.go
+++ b/IVssAsync.go
@@ -34,31 +34,20 @@ func (vssAsync *IVssAsync) getVTable() *IVssAsyncVTable {
 func (async *IVssAsync) Wait(miliseconds int) error {
 	code, _, _ := syscall.Syscall(async.getVTable().wait, 2, uintptr(unsafe.Pointer(async)), uintptr(miliseconds), 0)
 	if err := CreateVSSError("IVssAsync.Wait", code); err != nil {
-		async.Cancel()
 		return err
-	}
-
-	var status int32
-	code, _, _ = syscall.Syscall(async.getVTable().queryStatus, 3, uintptr(unsafe.Pointer(async)), uintptr(unsafe.Pointer(&status)), 0)
-	if err := CreateVSSError("IVssAsync.QueryStatus", code); err != nil {
-		async.Cancel()
-		return err
-	}
-
-	if HRESULT(status) == VSS_S_ASYNC_CANCELLED {
-		return CreateVSSError("IVssAsync.QueryStatus() returned cancelled status", uintptr(status))
-	}
-
-	if HRESULT(status) == VSS_S_ASYNC_PENDING {
-		async.Cancel()
-		return CreateVSSError("IVssAsync.QueryStatus() returned pending status", uintptr(status))
-	}
-
-	if HRESULT(status) != VSS_S_ASYNC_FINISHED {
-		return CreateVSSError("IVssAsync.QueryStatus() returned bad status", uintptr(status))
 	}
 
 	return nil
+}
+
+func (async *IVssAsync) QueryStatus() (int32, error) {
+	var status int32
+	code, _, _ := syscall.Syscall(async.getVTable().queryStatus, 3, uintptr(unsafe.Pointer(async)), uintptr(unsafe.Pointer(&status)), 0)
+	if err := CreateVSSError("IVssAsync.QueryStatus", code); err != nil {
+		return 0, err
+	}
+
+	return status, nil
 }
 
 func (async *IVssAsync) Cancel() error {

--- a/IVssBackupComponents.go
+++ b/IVssBackupComponents.go
@@ -175,7 +175,7 @@ func (vss *IVssBackupComponents) GatherWriterStatus() (*IVssAsync, error) {
 	}
 }
 
-// The GatherWriterStatus method prompts each writer to send a status message.
+// The FreeWriterStatus method frees system resources allocated during the call to IVssBackupComponents::GatherWriterStatus.
 func (vss *IVssBackupComponents) FreeWriterStatus() error {
 	code, _, _ := syscall.Syscall(vss.getVTable().freeWriterStatus, 1, uintptr(unsafe.Pointer(vss)), 0, 0)
 	return CreateVSSError("IVssBackupComponents.FreeWriterStatus", code)

--- a/vss_windows.go
+++ b/vss_windows.go
@@ -32,16 +32,16 @@ func doAsyncOperation(async *IVssAsync, timeout int) error {
 		return err
 	}
 
-	if HRESULT(status) == VSS_S_ASYNC_CANCELLED {
+	if status == VSS_S_ASYNC_CANCELLED {
 		return fmt.Errorf("async operation was cancelled")
 	}
 
-	if HRESULT(status) == VSS_S_ASYNC_PENDING {
+	if status == VSS_S_ASYNC_PENDING {
 		return fmt.Errorf("async operation is pending")
 	}
 
-	if HRESULT(status) != VSS_S_ASYNC_FINISHED {
-		return fmt.Errorf("async operation returned bad status - 0x%x", HRESULT(status))
+	if status != VSS_S_ASYNC_FINISHED {
+		return fmt.Errorf("async operation returned bad status - 0x%x", status)
 	}
 
 	return nil


### PR DESCRIPTION
Base implementation did not cancel the operation in case of an exceeding timeout.
This PR exposes all the methods in API wrapper and adds a proper timeout handler to Snapshotter.