### PR TITLE
Removed CGO dependecy

### DIFF
--- a/Dockerfile.win32
+++ b/Dockerfile.win32
@@ -12,8 +12,7 @@ RUN go mod download
 COPY / /go/src/project/vss/
 
 # Compile for Windows64
-RUN CGO_ENABLED="1" \
+RUN CGO_ENABLED="0" \
     GOARCH="386"\
     GOOS="windows"\
-    CC="i686-w64-mingw32-gcc"\
     go build -o /go/bin/vss.exe cmd/example/*

--- a/Dockerfile.win64
+++ b/Dockerfile.win64
@@ -12,8 +12,7 @@ RUN go mod download
 COPY / /go/src/project/vss/
 
 # Compile for Windows64
-RUN CGO_ENABLED="1" \
+RUN CGO_ENABLED="0" \
     GOARCH="amd64"\
     GOOS="windows"\
-    CC="x86_64-w64-mingw32-gcc"\
     go build -o /go/bin/vss.exe cmd/example/*

--- a/IVssBackupComponents.go
+++ b/IVssBackupComponents.go
@@ -4,7 +4,6 @@
 package vss
 
 import (
-	"C"
 	"fmt"
 	"runtime"
 	"syscall"

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,6 @@ build_win64:
 	docker image rm vss_windows_image_64
 
 build:
-	CGO_ENABLED="1" \
+	CGO_ENABLED="0" \
 	GOOS="windows" \
     go build -o bin/ cmd/example/*

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# Golang VSS module
-Windows API bindings for the `Volume Shadow Copy Service` in Golang for 32 and 64-bit systems. Enables the user to duplicate entire drives during runtime without any file access issues. The API bindings are accompanied by a simple CLI tool that creates and symlinks Shadow Copies of a given drive.
+# Golang VSS CGO-free module
+Windows API bindings for the `Volume Shadow Copy Service` in Golang for 32 and 64-bit systems. Enables the user to duplicate entire drives during runtime without any file access issues. The API bindings are accompanied by a simple CLI tool that creates and symlinks Shadow Copies of a given drive. Uses syscalls and go-ole to avoid CGo.
 ## Build
 You can either import the vss API bindings into your project or use the CLI application. The CLI application can be built with the following command:
 
@@ -13,8 +13,6 @@ Regular build on Windows:
 ```shell
 make build
 ```
-
-NOTE: When building you need to set the `CGO_ENABLED` environment variable to `1` and the `GOOS` environment variable to `windows`. The `GOARCH` environment variable should be set to `386` or `amd64` depending on the system you are building for.
 
 ## Usage
 ```sh


### PR DESCRIPTION
For unknown reasons this package included CGO without using it. Removing the reference in favor of cgo-less wrapper.