### PR TITLE
Fix VSS snapshot failure on recent Windows cumulative updates

### DIFF
--- a/IVssAsync.go
+++ b/IVssAsync.go
@@ -50,6 +50,15 @@ func (async *IVssAsync) QueryStatus() (HRESULT, error) {
 	return HRESULT(status), nil
 }
 
+// WaitRaw calls IVssAsync::Wait and returns the raw HRESULT.
+// Unlike Wait, it does not convert non-zero results to Go errors,
+// allowing the caller to distinguish timeout (S_OK with PENDING status)
+// from actual failures.
+func (async *IVssAsync) WaitRaw(miliseconds int) uintptr {
+	code, _, _ := syscall.Syscall(async.getVTable().wait, 2, uintptr(unsafe.Pointer(async)), uintptr(miliseconds), 0)
+	return code
+}
+
 func (async *IVssAsync) Cancel() error {
 	code, _, _ := syscall.Syscall(async.getVTable().cancel, 1, uintptr(unsafe.Pointer(async)), 0, 0)
 	return CreateVSSError("IVssAsync.cancel", code)

--- a/vss_windows.go
+++ b/vss_windows.go
@@ -5,6 +5,8 @@ package vss
 
 import (
 	"fmt"
+	"runtime"
+	"time"
 
 	"github.com/go-ole/go-ole"
 )
@@ -22,29 +24,56 @@ func doAsyncOperation(async *IVssAsync, timeout int) error {
 		async.Release()
 	}()
 
-	err := async.Wait(timeout)
-	if err != nil {
-		return err
+	// Use IVssAsync::Wait as the primary blocking mechanism.
+	hr := async.WaitRaw(timeout)
+
+	// Check status regardless of Wait result.
+	status, statusErr := async.QueryStatus()
+
+	if hr == 0 && statusErr == nil && status == VSS_S_ASYNC_FINISHED {
+		return nil
 	}
 
-	status, err := async.QueryStatus()
-	if err != nil {
-		return err
+	if statusErr == nil && status == VSS_S_ASYNC_FINISHED {
+		return nil
 	}
-
-	if status == VSS_S_ASYNC_CANCELLED {
+	if statusErr == nil && status == VSS_S_ASYNC_CANCELLED {
 		return fmt.Errorf("async operation was cancelled")
 	}
-
-	if status == VSS_S_ASYNC_PENDING {
-		return fmt.Errorf("async operation is pending")
+	if statusErr != nil {
+		return statusErr
 	}
-
-	if status != VSS_S_ASYNC_FINISHED {
+	if status != VSS_S_ASYNC_PENDING {
 		return fmt.Errorf("async operation returned bad status - 0x%x", status)
 	}
 
-	return nil
+	// IVssAsync::Wait returned but the operation is still pending.
+	// This happens when the Wait timeout is reached before the operation
+	// completes (e.g. GatherWriterMetadata can take longer than the
+	// timeout when a VSS writer's callback is slow to complete).
+	// Poll QueryStatus until the operation finishes or a second timeout
+	// window elapses.
+	deadline := time.Now().Add(time.Duration(timeout) * time.Millisecond)
+	for {
+		time.Sleep(100 * time.Millisecond)
+
+		status, err := async.QueryStatus()
+		if err != nil {
+			return err
+		}
+		switch {
+		case status == VSS_S_ASYNC_FINISHED:
+			return nil
+		case status == VSS_S_ASYNC_CANCELLED:
+			return fmt.Errorf("async operation was cancelled")
+		case status != VSS_S_ASYNC_PENDING:
+			return fmt.Errorf("async operation returned bad status - 0x%x", status)
+		}
+
+		if time.Now().After(deadline) {
+			return fmt.Errorf("async operation timed out")
+		}
+	}
 }
 
 func (v *Snapshotter) CreateSnapshot(drive string, bootable bool, timeout int) (s *Snapshot, rerr error) {
@@ -56,8 +85,16 @@ func (v *Snapshotter) CreateSnapshot(drive string, bootable bool, timeout int) (
 		timeout = _MIN_VSS_TIMEOUT
 	}
 
-	// Initalize COM Library
-	ole.CoInitialize(0)
+	// Pin this goroutine to the current OS thread for the lifetime of COM
+	// operations. COM apartment state is per-thread; without this, the Go
+	// scheduler could migrate the goroutine to a different OS thread between
+	// syscalls, breaking COM invariants.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	// Initialise COM in MTA mode. Microsoft's VSS documentation requires
+	// requestors to use COINIT_MULTITHREADED for IVssBackupComponents.
+	ole.CoInitializeEx(0, ole.COINIT_MULTITHREADED)
 	defer ole.CoUninitialize()
 	vssBackupComponent, err := LoadAndInitVSS()
 	if err != nil {


### PR DESCRIPTION
Summary

- Fix COM apartment model: switch from CoInitialize(0) (STA) to CoInitializeEx(COINIT_MULTITHREADED) (MTA) as required by
https://learn.microsoft.com/en-us/windows/win32/api/vsbackup/nl-vsbackup-ivssbackupcomponents
- Fix doAsyncOperation treating VSS_S_ASYNC_PENDING as fatal: add QueryStatus polling fallback when IVssAsync::Wait times out but the operation is still in progress
- Add runtime.LockOSThread to pin the goroutine for COM thread safety

Problem

After installing the February 2026 OS cumulative update on Windows Server 2022, GatherWriterMetadata fails with "async operation is pending". Two bugs combine to cause this:

1. STA instead of MTA. CoInitialize(0) puts COM in STA mode where writer callbacks arrive via the message queue, which the library never pumps. After the Windows update, this
causes GatherWriterMetadata to take ~182 seconds (waiting for an internal writer timeout) instead of completing in seconds.
2. No retry on PENDING. IVssAsync::Wait returns S_OK when it hits the 180-second timeout, but the operation hasn't finished yet — QueryStatus returns VSS_S_ASYNC_PENDING. The
original code treats this as a fatal error. The operation would have completed ~2 seconds later.

Verification

- Reproduced on a Windows Server 2022 host with the February 2026 cumulative update installed
- Unpatched go-vss v0.3.3: GatherWriterMetadata didn't finish properly, err: async operation is pending
- Patched binary: Snapshot created: {32B3BC46-...} — snapshot completes successfully
- vssadmin create shadow /for=C:\ works on the same server, confirming the VSS subsystem is healthy

Test plan

- Build and run cmd/example/ with -D C:\ on a Windows Server 2022 system with recent cumulative updates
- Verify snapshot creation succeeds
- Verify backwards compatibility on systems where GatherWriterMetadata completes within the timeout (the Wait path returns immediately on success, polling is never reached)
